### PR TITLE
Pass process.env onto child processes

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ async function resolveVersion(version, mirror) {
 })();
 
 function runScript(shell, script, version, mirror) {
-  const child = child_process.spawn(shell, [ script, version, mirror ], { cwd: __dirname });
+  const child = child_process.spawn(shell, [ script, version, mirror ], { ...process.env, cwd: __dirname });
   const stdout = [];
   child.stdout.on("data", out => {
     stdout.push(out);


### PR DESCRIPTION
Hi @dcodeIO,

Thank you for the great action.

We're using this action on some private repos and it looks like this line (https://github.com/actions/toolkit/blob/main/packages/core/src/core.ts#L69) inside `@actions/core` is causing us problems. It seems like `GITHUB_ENV` is not being found in the environment and so the library tries to use `add-path` method to add the directory to `PATH` which breaks of course!

It's odd that the unit tests for this action don't seem to be affected by my change and I can't seem to figure out why...

That said, in one of the repos where the build is failing this change has resolved the problem and is now passing again.

Do you think the change I've proposed is appropriate? :)

Many thanks